### PR TITLE
test(suite): complete testing suite todos and ui component coverage

### DIFF
--- a/components/screens/MapScreen/MapScreen.test.tsx
+++ b/components/screens/MapScreen/MapScreen.test.tsx
@@ -68,25 +68,35 @@ const withQuestState = {
  *   Then the quest shield shows "None Accepted"
  */
 describe("MapScreen", () => {
+  beforeAll(() => {
+    Element.prototype.getAnimations = () => [];
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
   });
 
-  it("renders the compass map image", () => {
-    renderWithStore(<MapScreen />, noQuestState);
+  it("renders the compass map image", async () => {
+    await act(async () => {
+      renderWithStore(<MapScreen />, noQuestState);
+    });
     // Both map icons share alt="Compass Icon" — known copy-paste in source; assert at least one renders
     expect(screen.getAllByAltText("Compass Icon").length).toBeGreaterThan(0);
   });
 
-  it('shows "None Accepted" when no quest is in state', () => {
-    renderWithStore(<MapScreen />, noQuestState);
+  it('shows "None Accepted" when no quest is in state', async () => {
+    await act(async () => {
+      renderWithStore(<MapScreen />, noQuestState);
+    });
     expect(screen.getByText(/none accepted/i)).toBeInTheDocument();
   });
 
   it("clicking the quest shield and confirming navigates to /storyscreen", async () => {
     jest.useFakeTimers();
-    renderWithStore(<MapScreen />, withQuestState);
+    await act(async () => {
+      renderWithStore(<MapScreen />, withQuestState);
+    });
 
     fireEvent.click(screen.getByText(/ambush alley recon/i));
     fireEvent.click(screen.getByRole("button", { name: /commence quest/i }));

--- a/components/screens/MapScreen/MapScreen.test.tsx
+++ b/components/screens/MapScreen/MapScreen.test.tsx
@@ -1,37 +1,55 @@
-import React from 'react';
-import '@testing-library/jest-dom';
-import { screen, fireEvent, act } from '@testing-library/react';
-import { renderWithStore } from '@/lib/test-utils';
-import MapScreen from './MapScreen';
-import type { QuestStory } from '@/types/quest';
+import React from "react";
+import "@testing-library/jest-dom";
+import { screen, fireEvent, act } from "@testing-library/react";
+import { renderWithStore } from "@/lib/test-utils";
+import MapScreen from "./MapScreen";
+import type { QuestStory } from "@/types/quest";
 
 const mockPush = jest.fn();
-jest.mock('next/navigation', () => ({
+jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
-  usePathname: jest.fn(() => '/'),
+  usePathname: jest.fn(() => "/"),
 }));
 
-jest.mock('@/lib/hooks/useProtectedRoute', () => ({
+jest.mock("@/lib/hooks/useProtectedRoute", () => ({
   __esModule: true,
   default: jest.fn(),
 }));
 
 const mockQuest: QuestStory = {
-  id: 'ambushReconQuest',
-  name: 'Ambush Alley Recon',
-  description: 'Scout the bandit camp.',
-  coverImageSrc: '/quests/ambush_cover.png',
+  id: "ambushReconQuest",
+  name: "Ambush Alley Recon",
+  description: "Scout the bandit camp.",
+  coverImageSrc: "/quests/ambush_cover.png",
   storyPoints: [],
 };
 
 const noQuestState = {
-  quest: { acceptedQuest: null, currentStoryPointId: null, lastEndedQuestId: null, pendingBattleDetails: null },
-  character: { ActiveCharacter: null, party: [], characterLocation: null, completedQuestIds: [], characterSnapshot: null },
+  quest: {
+    availableQuests: [mockQuest],
+    acceptedQuest: null,
+    currentStoryPointId: null,
+    lastEndedQuestId: null,
+    pendingBattleDetails: null,
+  },
+  character: {
+    ActiveCharacter: null,
+    party: [],
+    characterLocation: null,
+    completedQuestIds: [],
+    characterSnapshot: null,
+  },
 };
 
 const withQuestState = {
   ...noQuestState,
-  quest: { acceptedQuest: mockQuest, currentStoryPointId: 'sp1', lastEndedQuestId: null, pendingBattleDetails: null },
+  quest: {
+    availableQuests: [mockQuest],
+    acceptedQuest: mockQuest,
+    currentStoryPointId: "sp1",
+    lastEndedQuestId: null,
+    pendingBattleDetails: null,
+  },
 };
 
 /*
@@ -49,16 +67,16 @@ const withQuestState = {
  *   When I view the map
  *   Then the quest shield shows "None Accepted"
  */
-describe('MapScreen', () => {
+describe("MapScreen", () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
   });
 
-  it('renders the compass map image', () => {
+  it("renders the compass map image", () => {
     renderWithStore(<MapScreen />, noQuestState);
     // Both map icons share alt="Compass Icon" — known copy-paste in source; assert at least one renders
-    expect(screen.getAllByAltText('Compass Icon').length).toBeGreaterThan(0);
+    expect(screen.getAllByAltText("Compass Icon").length).toBeGreaterThan(0);
   });
 
   it('shows "None Accepted" when no quest is in state', () => {
@@ -66,17 +84,17 @@ describe('MapScreen', () => {
     expect(screen.getByText(/none accepted/i)).toBeInTheDocument();
   });
 
-  it('clicking the quest shield and confirming navigates to /storyscreen', async () => {
+  it("clicking the quest shield and confirming navigates to /storyscreen", async () => {
     jest.useFakeTimers();
     renderWithStore(<MapScreen />, withQuestState);
 
     fireEvent.click(screen.getByText(/ambush alley recon/i));
-    fireEvent.click(screen.getByRole('button', { name: /commence quest/i }));
+    fireEvent.click(screen.getByRole("button", { name: /commence quest/i }));
 
     await act(async () => {
       jest.runAllTimers();
     });
 
-    expect(mockPush).toHaveBeenCalledWith('/storyscreen');
+    expect(mockPush).toHaveBeenCalledWith("/storyscreen");
   });
 });

--- a/components/screens/QuestBoardScreen/QuestBoardScreen.test.tsx
+++ b/components/screens/QuestBoardScreen/QuestBoardScreen.test.tsx
@@ -1,35 +1,48 @@
-import React from 'react';
-import '@testing-library/jest-dom';
-import { screen, fireEvent, act } from '@testing-library/react';
-import { renderWithStore } from '@/lib/test-utils';
-import QuestBoardScreen from './QuestBoardScreen';
-import type { QuestStory } from '@/types/quest';
+import React from "react";
+import "@testing-library/jest-dom";
+import { screen, fireEvent, act } from "@testing-library/react";
+import { renderWithStore } from "@/lib/test-utils";
+import QuestBoardScreen from "./QuestBoardScreen";
+import type { QuestStory } from "@/types/quest";
 
-jest.mock('next/navigation', () => ({
+jest.mock("next/navigation", () => ({
   useRouter: jest.fn(() => ({ push: jest.fn() })),
-  usePathname: jest.fn(() => '/'),
+  usePathname: jest.fn(() => "/"),
 }));
 
-jest.mock('@/lib/hooks/useProtectedRoute', () => ({
+jest.mock("@/lib/hooks/useProtectedRoute", () => ({
   __esModule: true,
   default: jest.fn(),
 }));
 
 const baseState = {
-  quest: { acceptedQuest: null, currentStoryPointId: null, lastEndedQuestId: null, pendingBattleDetails: null },
+  quest: {
+    availableQuests: [],
+    acceptedQuest: null,
+    currentStoryPointId: null,
+    lastEndedQuestId: null,
+    pendingBattleDetails: null,
+  },
 };
 
 const enabledQuest: QuestStory = {
-  id: 'ambushReconQuest',
-  name: 'Ambush Alley Recon',
-  description: 'Scout the bandit camp.',
-  coverImageSrc: '/quests/ambush_cover.png',
+  id: "ambushReconQuest",
+  name: "Ambush Alley Recon",
+  description: "Scout the bandit camp.",
+  coverImageSrc: "/quests/ambush_cover.png",
   storyPoints: [
     {
-      id: 'sp1',
-      imageSrc: '/sp1.png',
-      text: 'You reach the ambush point.',
-      choices: [{ label: 'a', text: 'Continue', nextPointId: null, outcome: { endState: 'completed' } }],
+      id: "sp1",
+      imageSrc: "/sp1.png",
+      text: "You reach the ambush point.",
+      choices: [
+        {
+          label: "a",
+          text: "Continue",
+          nextPointId: null,
+          outcome: { endState: "completed" },
+        },
+      ],
     },
   ],
 };
@@ -54,23 +67,23 @@ const enabledQuest: QuestStory = {
  *   When I view the Quest Board
  *   Then the accepted quest image has a highlight class applied
  */
-describe('QuestBoardScreen', () => {
+describe("QuestBoardScreen", () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
   });
 
-  it('renders quest cards from the quest data', () => {
+  it("renders quest cards from the quest data", () => {
     renderWithStore(<QuestBoardScreen />, baseState);
     expect(screen.getByText(enabledQuest.name)).toBeInTheDocument();
   });
 
-  it('clicking a quest and accepting it updates store state', async () => {
+  it("clicking a quest and accepting it updates store state", async () => {
     jest.useFakeTimers();
     const { store } = renderWithStore(<QuestBoardScreen />, baseState);
 
     fireEvent.click(screen.getByAltText(`${enabledQuest.name} Quest Image`));
-    fireEvent.click(screen.getByRole('button', { name: /accept/i }));
+    fireEvent.click(screen.getByRole("button", { name: /accept/i }));
 
     await act(async () => {
       jest.runAllTimers();
@@ -79,9 +92,10 @@ describe('QuestBoardScreen', () => {
     expect(store.getState().quest.acceptedQuest?.id).toBe(enabledQuest.id);
   });
 
-  it('the accepted quest image has a highlight class', () => {
+  it("the accepted quest image has a highlight class", () => {
     const acceptedState = {
       quest: {
+        availableQuests: [enabledQuest],
         acceptedQuest: enabledQuest,
         currentStoryPointId: enabledQuest.storyPoints[0]?.id ?? null,
         lastEndedQuestId: null,
@@ -90,6 +104,6 @@ describe('QuestBoardScreen', () => {
     };
     renderWithStore(<QuestBoardScreen />, acceptedState);
     const questImg = screen.getByAltText(`${enabledQuest.name} Quest Image`);
-    expect(questImg).toHaveClass('ring-yellow-300');
+    expect(questImg).toHaveClass("ring-yellow-300");
   });
 });

--- a/components/screens/QuestBoardScreen/QuestBoardScreen.test.tsx
+++ b/components/screens/QuestBoardScreen/QuestBoardScreen.test.tsx
@@ -68,19 +68,28 @@ const enabledQuest: QuestStory = {
  *   Then the accepted quest image has a highlight class applied
  */
 describe("QuestBoardScreen", () => {
+  beforeAll(() => {
+    Element.prototype.getAnimations = () => [];
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
   });
 
-  it("renders quest cards from the quest data", () => {
-    renderWithStore(<QuestBoardScreen />, baseState);
+  it("renders quest cards from the quest data", async () => {
+    await act(async () => {
+      renderWithStore(<QuestBoardScreen />, baseState);
+    });
     expect(screen.getByText(enabledQuest.name)).toBeInTheDocument();
   });
 
   it("clicking a quest and accepting it updates store state", async () => {
     jest.useFakeTimers();
-    const { store } = renderWithStore(<QuestBoardScreen />, baseState);
+    let store!: ReturnType<typeof renderWithStore>["store"];
+    await act(async () => {
+      ({ store } = renderWithStore(<QuestBoardScreen />, baseState));
+    });
 
     fireEvent.click(screen.getByAltText(`${enabledQuest.name} Quest Image`));
     fireEvent.click(screen.getByRole("button", { name: /accept/i }));
@@ -92,7 +101,7 @@ describe("QuestBoardScreen", () => {
     expect(store.getState().quest.acceptedQuest?.id).toBe(enabledQuest.id);
   });
 
-  it("the accepted quest image has a highlight class", () => {
+  it("the accepted quest image has a highlight class", async () => {
     const acceptedState = {
       quest: {
         availableQuests: [enabledQuest],
@@ -102,7 +111,9 @@ describe("QuestBoardScreen", () => {
         pendingBattleDetails: null,
       },
     };
-    renderWithStore(<QuestBoardScreen />, acceptedState);
+    await act(async () => {
+      renderWithStore(<QuestBoardScreen />, acceptedState);
+    });
     const questImg = screen.getByAltText(`${enabledQuest.name} Quest Image`);
     expect(questImg).toHaveClass("ring-yellow-300");
   });

--- a/components/screens/SplashScreen/SplashScreen.test.tsx
+++ b/components/screens/SplashScreen/SplashScreen.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -20,23 +20,33 @@ jest.mock('@/components/ui/LoginModal/LoginModal', () => ({
 }));
 
 describe('SplashScreen', () => {
-  it('Component renders', () => {
-    render(<SplashScreen />);
+  beforeAll(() => {
+    Element.prototype.getAnimations = () => [];
+  });
+
+  it('Component renders', async () => {
+    await act(async () => {
+      render(<SplashScreen />);
+    });
     expect(screen.getByRole('img', { name: /isekai quest logo/i })).toBeInTheDocument();
   });
 
   describe('Start Quest loading spinner', () => {
     it('shows a loading spinner when Start Quest is clicked', async () => {
       const user = userEvent.setup();
-      render(<SplashScreen />);
+      await act(async () => {
+        render(<SplashScreen />);
+      });
 
       await user.click(screen.getByRole('button', { name: /start quest/i }));
 
       expect(screen.getByRole('status')).toBeInTheDocument();
     });
 
-    it('does not show a loading spinner before Start Quest is clicked', () => {
-      render(<SplashScreen />);
+    it('does not show a loading spinner before Start Quest is clicked', async () => {
+      await act(async () => {
+        render(<SplashScreen />);
+      });
 
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });

--- a/components/ui/BackButton/BackButton.test.tsx
+++ b/components/ui/BackButton/BackButton.test.tsx
@@ -1,4 +1,42 @@
-describe('BackButton', () => {
-  test.todo('renders a back button');
-  test.todo('clicking navigates to the previous page');
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import BackButton from "./BackButton";
+
+const mockBack = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({ back: mockBack })),
+}));
+
+/*
+ * Story: Player navigates back from a screen
+ * In order to return to the previous screen,
+ * a player wants to click a back button that takes them to where they came from.
+ *
+ * Scenario: Back button is visible on the screen
+ *   Given I am on any screen with a BackButton
+ *   When the component renders
+ *   Then I should see the back button image
+ *
+ * Scenario: Player clicks the back button
+ *   Given I am on a screen with a BackButton
+ *   When I click the back button
+ *   Then I should be navigated to the previous page
+ */
+describe("BackButton", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders a back button", () => {
+    render(<BackButton />);
+    expect(screen.getByAltText("Back Icon")).toBeInTheDocument();
+  });
+
+  it("clicking navigates to the previous page", () => {
+    render(<BackButton />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
 });

--- a/components/ui/CharacterDisplayCard/CharacterDisplayCard.test.tsx
+++ b/components/ui/CharacterDisplayCard/CharacterDisplayCard.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import CharacterDisplayCard from "./CharacterDisplayCard";
+import { Character } from "@/types/character";
+
+const mockCharacter: Character = {
+  id: "char-001",
+  name: "Aric",
+  avatar: "/character_avatars/aric.png",
+  hp: 100,
+  mp: 50,
+  inventory: {
+    attacks: [],
+    skills: [],
+    coins: { gold: 0, silver: 0, copper: 0 },
+    weapons: [],
+    equipment: [],
+    rations: [],
+    potions: [],
+    questItems: [],
+  },
+};
+
+/*
+ * Story: Player views a character's stats on a display card
+ * In order to review their party members,
+ * a player wants to see a character's name, HP, and MP displayed on a card.
+ *
+ * Scenario: Character card renders the character's name
+ *   Given a character with a name
+ *   When the CharacterDisplayCard renders
+ *   Then I should see the character's name
+ *
+ * Scenario: Character card renders HP and MP stats
+ *   Given a character with HP and MP values
+ *   When the CharacterDisplayCard renders
+ *   Then I should see the correct HP and MP values
+ *
+ * Scenario: Character card renders the character avatar
+ *   Given a character with an avatar
+ *   When the CharacterDisplayCard renders
+ *   Then I should see the character's avatar image
+ */
+describe("CharacterDisplayCard", () => {
+  it("renders the character name", () => {
+    render(<CharacterDisplayCard character={mockCharacter} />);
+    expect(screen.getByText("Aric")).toBeInTheDocument();
+  });
+
+  it("renders the character HP and MP stats", () => {
+    render(<CharacterDisplayCard character={mockCharacter} />);
+    expect(screen.getByText("HP: 100")).toBeInTheDocument();
+    expect(screen.getByText("MP: 50")).toBeInTheDocument();
+  });
+
+  it("renders the character avatar image", () => {
+    render(<CharacterDisplayCard character={mockCharacter} />);
+    expect(screen.getByAltText("Aric")).toBeInTheDocument();
+  });
+});

--- a/components/ui/CoinPanel/CoinsPanel.test.tsx
+++ b/components/ui/CoinPanel/CoinsPanel.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import CoinsPanel, { formatCoinsForDisplay } from "./CoinsPanel";
+import { Coins } from "@/types/character";
+
+const mockCoins: Coins = {
+  gold: 10,
+  silver: 25,
+  copper: 50,
+};
+
+/*
+ * Story: Player views their coin totals in the Coins Panel
+ * In order to track their wealth,
+ * a player wants to see their gold, silver, and copper counts displayed.
+ *
+ * Scenario: Panel renders all three coin types with correct counts
+ *   Given a player with coins
+ *   When the CoinsPanel renders
+ *   Then I should see gold, silver, and copper counts
+ *
+ * Scenario: Panel renders with zero counts when no coins are provided
+ *   Given no coin data is passed
+ *   When the CoinsPanel renders
+ *   Then all coin counts should display as zero
+ *
+ * Scenario: formatCoinsForDisplay returns correct structure
+ *   Given a coins object
+ *   When formatCoinsForDisplay is called
+ *   Then it should return gold, silver, and copper in the correct order with correct counts
+ */
+describe("CoinsPanel", () => {
+  it("renders all three coin types with correct counts", () => {
+    render(<CoinsPanel coins={mockCoins} />);
+    expect(screen.getByText("Gold: 10")).toBeInTheDocument();
+    expect(screen.getByText("Silver: 25")).toBeInTheDocument();
+    expect(screen.getByText("Copper: 50")).toBeInTheDocument();
+  });
+
+  it("renders zero counts when no coins are provided", () => {
+    render(<CoinsPanel coins={undefined} />);
+    expect(screen.getByText("Gold: 0")).toBeInTheDocument();
+    expect(screen.getByText("Silver: 0")).toBeInTheDocument();
+    expect(screen.getByText("Copper: 0")).toBeInTheDocument();
+  });
+
+  describe("formatCoinsForDisplay", () => {
+    it("returns correct structure and order for given coins", () => {
+      const result = formatCoinsForDisplay(mockCoins);
+      expect(result[0]).toMatchObject({ title: "Gold", count: 10 });
+      expect(result[1]).toMatchObject({ title: "Silver", count: 25 });
+      expect(result[2]).toMatchObject({ title: "Copper", count: 50 });
+    });
+  });
+});

--- a/components/ui/CommenceModal/CommenceModal.test.tsx
+++ b/components/ui/CommenceModal/CommenceModal.test.tsx
@@ -1,5 +1,97 @@
-describe('CommenceModal', () => {
-  test.todo('renders quest info when isOpen is true');
-  test.todo('clicking Commence Quest calls commenceQuest callback');
-  test.todo('clicking Cancel closes the modal');
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import CommenceModal from "./CommenceModal";
+import type { QuestStory } from "@/types/quest";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({ push: jest.fn() })),
+}));
+
+const mockCloseModal = jest.fn();
+const mockCommenceQuest = jest.fn();
+
+const mockQuest: QuestStory = {
+  id: "ambushReconQuest",
+  name: "Ambush Alley Recon",
+  description: "Scout the bandit camp.",
+  coverImageSrc: "/quests/ambush_cover.png",
+  storyPoints: [],
+};
+
+/*
+ * Story: Player commences an accepted quest
+ * In order to begin their adventure,
+ * a player wants to confirm and start their accepted quest via the CommenceModal.
+ *
+ * Scenario: Modal displays quest info when open
+ *   Given I have an accepted quest
+ *   When the CommenceModal is open
+ *   Then I should see the quest name and description
+ *
+ * Scenario: Player clicks Commence Quest
+ *   Given the CommenceModal is open with a quest
+ *   When I click the Commence Quest button
+ *   Then the commenceQuest callback should be called
+ *
+ * Scenario: Player clicks Cancel
+ *   Given the CommenceModal is open
+ *   When I click the Cancel button
+ *   Then the modal should close
+ */
+describe("CommenceModal", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("renders quest info when isOpen is true", () => {
+    render(
+      <CommenceModal
+        isOpen={true}
+        quest={mockQuest}
+        closeModal={mockCloseModal}
+        commenceQuest={mockCommenceQuest}
+      />,
+    );
+
+    expect(screen.getByText(mockQuest.name)).toBeInTheDocument();
+    expect(screen.getByText(mockQuest.description)).toBeInTheDocument();
+  });
+
+  it("clicking Commence Quest calls commenceQuest callback", async () => {
+    jest.useFakeTimers();
+
+    render(
+      <CommenceModal
+        isOpen={true}
+        quest={mockQuest}
+        closeModal={mockCloseModal}
+        commenceQuest={mockCommenceQuest}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /commence quest/i }));
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(mockCommenceQuest).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking Cancel closes the modal", () => {
+    render(
+      <CommenceModal
+        isOpen={true}
+        quest={mockQuest}
+        closeModal={mockCloseModal}
+        commenceQuest={mockCommenceQuest}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(mockCloseModal).toHaveBeenCalledTimes(1);
+  });
 });

--- a/components/ui/CommenceModal/CommenceModal.test.tsx
+++ b/components/ui/CommenceModal/CommenceModal.test.tsx
@@ -40,20 +40,25 @@ const mockQuest: QuestStory = {
  *   Then the modal should close
  */
 describe("CommenceModal", () => {
+  beforeAll(() => {
+    Element.prototype.getAnimations = () => [];
+  });
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
   });
 
-  it("renders quest info when isOpen is true", () => {
-    render(
-      <CommenceModal
-        isOpen={true}
-        quest={mockQuest}
-        closeModal={mockCloseModal}
-        commenceQuest={mockCommenceQuest}
-      />,
-    );
+  it("renders quest info when isOpen is true", async () => {
+    await act(async () => {
+      render(
+        <CommenceModal
+          isOpen={true}
+          quest={mockQuest}
+          closeModal={mockCloseModal}
+          commenceQuest={mockCommenceQuest}
+        />,
+      );
+    });
 
     expect(screen.getByText(mockQuest.name)).toBeInTheDocument();
     expect(screen.getByText(mockQuest.description)).toBeInTheDocument();
@@ -62,14 +67,16 @@ describe("CommenceModal", () => {
   it("clicking Commence Quest calls commenceQuest callback", async () => {
     jest.useFakeTimers();
 
-    render(
-      <CommenceModal
-        isOpen={true}
-        quest={mockQuest}
-        closeModal={mockCloseModal}
-        commenceQuest={mockCommenceQuest}
-      />,
-    );
+    await act(async () => {
+      render(
+        <CommenceModal
+          isOpen={true}
+          quest={mockQuest}
+          closeModal={mockCloseModal}
+          commenceQuest={mockCommenceQuest}
+        />,
+      );
+    });
 
     fireEvent.click(screen.getByRole("button", { name: /commence quest/i }));
 
@@ -80,15 +87,17 @@ describe("CommenceModal", () => {
     expect(mockCommenceQuest).toHaveBeenCalledTimes(1);
   });
 
-  it("clicking Cancel closes the modal", () => {
-    render(
-      <CommenceModal
-        isOpen={true}
-        quest={mockQuest}
-        closeModal={mockCloseModal}
-        commenceQuest={mockCommenceQuest}
-      />,
-    );
+  it("clicking Cancel closes the modal", async () => {
+    await act(async () => {
+      render(
+        <CommenceModal
+          isOpen={true}
+          quest={mockQuest}
+          closeModal={mockCloseModal}
+          commenceQuest={mockCommenceQuest}
+        />,
+      );
+    });
 
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
 

--- a/components/ui/ControlPanel/ContolPanel.test.tsx
+++ b/components/ui/ControlPanel/ContolPanel.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { screen } from "@testing-library/react";
+import { renderWithStore } from "@/lib/test-utils";
+import { ControlPanel } from "./ContolPanel";
+import { usePathname } from "next/navigation";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({ push: mockPush })),
+  usePathname: jest.fn(),
+}));
+
+jest.mock("@/lib/persistence/localPersistence", () => ({
+  clearSessionRefreshData: jest.fn(),
+}));
+
+const baseState = {
+  auth: {
+    isAuthenticated: false,
+    user: null,
+  },
+  quest: {
+    availableQuests: [],
+    acceptedQuest: null,
+    currentStoryPointId: null,
+    lastEndedQuestId: null,
+    pendingBattleDetails: null,
+  },
+  character: {
+    ActiveCharacter: null,
+    characterLocation: null,
+    party: [],
+    completedQuestIds: [],
+    characterData: null,
+    location: null,
+    characterSnapshot: null,
+  },
+};
+
+/*
+ * Story: Player navigates using the Control Panel
+ * In order to move between screens,
+ * a player wants to see relevant navigation buttons based on which screen they are on.
+ *
+ * Scenario: Map and Party buttons are visible on a standard screen
+ *   Given I am on a screen that is not the map, party, or home screen
+ *   When the ControlPanel renders
+ *   Then I should see the Map and Party buttons
+ *
+ * Scenario: Map button is hidden on the map screen
+ *   Given I am on the map screen
+ *   When the ControlPanel renders
+ *   Then the Map button should not be visible
+ *
+ * Scenario: Party button is hidden on the party screen
+ *   Given I am on the party screen
+ *   When the ControlPanel renders
+ *   Then the Party button should not be visible
+ *
+ * Scenario: Back button is hidden on the home screen
+ *   Given I am on the home screen
+ *   When the ControlPanel renders
+ *   Then the Back button should not be visible
+ */
+describe("ControlPanel", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders Map and Party buttons on a standard screen", () => {
+    (usePathname as jest.Mock).mockReturnValue("/questboard");
+    renderWithStore(<ControlPanel />, baseState);
+    expect(screen.getByAltText("Map Icon")).toBeInTheDocument();
+    expect(screen.getByAltText("Party Icon")).toBeInTheDocument();
+  });
+
+  it("hides the Map button on the map screen", () => {
+    (usePathname as jest.Mock).mockReturnValue("/mapscreen");
+    renderWithStore(<ControlPanel />, baseState);
+    expect(screen.queryByAltText("Map Icon")).not.toBeInTheDocument();
+  });
+
+  it("hides the Party button on the party screen", () => {
+    (usePathname as jest.Mock).mockReturnValue("/partyscreen");
+    renderWithStore(<ControlPanel />, baseState);
+    expect(screen.queryByAltText("Party Icon")).not.toBeInTheDocument();
+  });
+
+  it("hides the Back button on the home screen", () => {
+    (usePathname as jest.Mock).mockReturnValue("/homescreen");
+    renderWithStore(<ControlPanel />, baseState);
+    expect(screen.queryByAltText("Back Icon")).not.toBeInTheDocument();
+  });
+});

--- a/components/ui/DetailsModal/DetailsModal.test.tsx
+++ b/components/ui/DetailsModal/DetailsModal.test.tsx
@@ -1,5 +1,94 @@
-describe('DetailsModal', () => {
-  test.todo('renders quest details when isOpen is true');
-  test.todo('clicking Accept dispatches setAcceptedQuest');
-  test.todo('clicking Cancel closes the modal');
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import DetailsModal from "./DetailsModal";
+import type { QuestStory } from "@/types/quest";
+
+const mockCloseModal = jest.fn();
+const mockAcceptQuest = jest.fn();
+
+const mockQuest: QuestStory = {
+  id: "ambushReconQuest",
+  name: "Ambush Alley Recon",
+  description: "Scout the bandit camp.",
+  coverImageSrc: "/quests/ambush_cover.png",
+  storyPoints: [],
+};
+
+/*
+ * Story: Player views and accepts a quest from the Details Modal
+ * In order to commit to an adventure,
+ * a player wants to review quest details and accept it from the DetailsModal.
+ *
+ * Scenario: Modal displays quest details when open
+ *   Given I have selected a quest
+ *   When the DetailsModal is open
+ *   Then I should see the quest name and description
+ *
+ * Scenario: Player clicks Accept
+ *   Given the DetailsModal is open with a quest
+ *   When I click the Accept button
+ *   Then the acceptQuest callback should be called with the quest
+ *
+ * Scenario: Player clicks Cancel
+ *   Given the DetailsModal is open
+ *   When I click the Cancel button
+ *   Then the modal should close
+ */
+describe("DetailsModal", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("renders quest details when isOpen is true", () => {
+    render(
+      <DetailsModal
+        isOpen={true}
+        quest={mockQuest}
+        closeModal={mockCloseModal}
+        acceptQuest={mockAcceptQuest}
+      />,
+    );
+
+    expect(screen.getByText(mockQuest.name)).toBeInTheDocument();
+    expect(screen.getByText(mockQuest.description)).toBeInTheDocument();
+  });
+
+  it("clicking Accept dispatches setAcceptedQuest", async () => {
+    jest.useFakeTimers();
+
+    render(
+      <DetailsModal
+        isOpen={true}
+        quest={mockQuest}
+        closeModal={mockCloseModal}
+        acceptQuest={mockAcceptQuest}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /accept/i }));
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(mockAcceptQuest).toHaveBeenCalledTimes(1);
+    expect(mockAcceptQuest).toHaveBeenCalledWith(mockQuest);
+  });
+
+  it("clicking Cancel closes the modal", () => {
+    render(
+      <DetailsModal
+        isOpen={true}
+        quest={mockQuest}
+        closeModal={mockCloseModal}
+        acceptQuest={mockAcceptQuest}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(mockCloseModal).toHaveBeenCalledTimes(1);
+  });
 });

--- a/components/ui/DetailsModal/DetailsModal.test.tsx
+++ b/components/ui/DetailsModal/DetailsModal.test.tsx
@@ -36,20 +36,26 @@ const mockQuest: QuestStory = {
  *   Then the modal should close
  */
 describe("DetailsModal", () => {
+  beforeAll(() => {
+    Element.prototype.getAnimations = () => [];
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
   });
 
-  it("renders quest details when isOpen is true", () => {
-    render(
-      <DetailsModal
-        isOpen={true}
-        quest={mockQuest}
-        closeModal={mockCloseModal}
-        acceptQuest={mockAcceptQuest}
-      />,
-    );
+  it("renders quest details when isOpen is true", async () => {
+    await act(async () => {
+      render(
+        <DetailsModal
+          isOpen={true}
+          quest={mockQuest}
+          closeModal={mockCloseModal}
+          acceptQuest={mockAcceptQuest}
+        />,
+      );
+    });
 
     expect(screen.getByText(mockQuest.name)).toBeInTheDocument();
     expect(screen.getByText(mockQuest.description)).toBeInTheDocument();
@@ -58,14 +64,16 @@ describe("DetailsModal", () => {
   it("clicking Accept dispatches setAcceptedQuest", async () => {
     jest.useFakeTimers();
 
-    render(
-      <DetailsModal
-        isOpen={true}
-        quest={mockQuest}
-        closeModal={mockCloseModal}
-        acceptQuest={mockAcceptQuest}
-      />,
-    );
+    await act(async () => {
+      render(
+        <DetailsModal
+          isOpen={true}
+          quest={mockQuest}
+          closeModal={mockCloseModal}
+          acceptQuest={mockAcceptQuest}
+        />,
+      );
+    });
 
     fireEvent.click(screen.getByRole("button", { name: /accept/i }));
 
@@ -77,15 +85,17 @@ describe("DetailsModal", () => {
     expect(mockAcceptQuest).toHaveBeenCalledWith(mockQuest);
   });
 
-  it("clicking Cancel closes the modal", () => {
-    render(
-      <DetailsModal
-        isOpen={true}
-        quest={mockQuest}
-        closeModal={mockCloseModal}
-        acceptQuest={mockAcceptQuest}
-      />,
-    );
+  it("clicking Cancel closes the modal", async () => {
+    await act(async () => {
+      render(
+        <DetailsModal
+          isOpen={true}
+          quest={mockQuest}
+          closeModal={mockCloseModal}
+          acceptQuest={mockAcceptQuest}
+        />,
+      );
+    });
 
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
 

--- a/components/ui/GameDataProvider/GameDataProvider.test.tsx
+++ b/components/ui/GameDataProvider/GameDataProvider.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { screen } from "@testing-library/react";
+import { renderWithStore } from "@/lib/test-utils";
+import { GameDataProvider } from "./GameDataProvider";
+
+const baseState = {
+  auth: {
+    isAuthenticated: false,
+    user: null,
+  },
+  quest: {
+    availableQuests: [],
+    acceptedQuest: null,
+    currentStoryPointId: null,
+    lastEndedQuestId: null,
+    pendingBattleDetails: null,
+  },
+  character: {
+    ActiveCharacter: null,
+    characterLocation: null,
+    party: [],
+    completedQuestIds: [],
+    characterData: null,
+    location: null,
+    characterSnapshot: null,
+  },
+};
+
+/*
+ * Story: Game data is loaded when the app initializes
+ * In order to populate the game world,
+ * the GameDataProvider dispatches available quest data into the Redux store on mount.
+ *
+ * Scenario: Children are rendered by the provider
+ *   Given the GameDataProvider wraps child content
+ *   When the component mounts
+ *   Then the child content should be visible
+ *
+ * Scenario: Available quests are dispatched to the store on mount
+ *   Given the GameDataProvider mounts with an empty quest state
+ *   When the component renders
+ *   Then the store should contain the available quests
+ */
+describe("GameDataProvider", () => {
+  it("renders its children", () => {
+    renderWithStore(
+      <GameDataProvider>
+        <div>Child Content</div>
+      </GameDataProvider>,
+      baseState,
+    );
+    expect(screen.getByText("Child Content")).toBeInTheDocument();
+  });
+
+  it("dispatches available quests to the store on mount", () => {
+    const { store } = renderWithStore(
+      <GameDataProvider>
+        <div>Child Content</div>
+      </GameDataProvider>,
+      baseState,
+    );
+    expect(store.getState().quest.availableQuests.length).toBeGreaterThan(0);
+  });
+});

--- a/components/ui/InformationIcon/InformationIcon.test.tsx
+++ b/components/ui/InformationIcon/InformationIcon.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { InformationIcon } from "./InformationIcon";
+import { InformationPageKey } from "@/types/information";
+
+jest.mock("@/data/information/InformationContent", () => ({
+  InformationContentObject: {
+    splash: {
+      title: "Splash Page",
+      imageSrc: "/information_images/splash.png",
+      content: "This is test information content.",
+    },
+  },
+}));
+
+jest.mock("../ModalBase/ModalBase", () => ({
+  ModalBase: ({
+    isOpen,
+    children,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+  }) => (isOpen ? <div data-testid="modal-base">{children}</div> : null),
+}));
+
+/*
+ * Story: Player views information about a game screen
+ * In order to learn about the game mechanics,
+ * a player wants to click an information icon to open a modal with relevant content.
+ *
+ * Scenario: Information icon renders when content exists for the page key
+ *   Given a valid page key with content
+ *   When the InformationIcon renders
+ *   Then the information icon button should be visible
+ *
+ * Scenario: Information icon renders nothing when no content exists for the key
+ *   Given an invalid page key with no content
+ *   When the InformationIcon renders
+ *   Then nothing should be rendered
+ *
+ * Scenario: Clicking the icon opens the modal with content
+ *   Given the InformationIcon is rendered with a valid page key
+ *   When I click the information icon
+ *   Then the modal should open and display the page content
+ */
+describe("InformationIcon", () => {
+  it("renders the information icon button when content exists", () => {
+    render(<InformationIcon pageKey={"splash"} />);
+    expect(screen.getByAltText("Information Icon")).toBeInTheDocument();
+  });
+
+  it("renders nothing when no content exists for the page key", () => {
+    render(<InformationIcon pageKey={"unknownPage" as InformationPageKey} />);
+    expect(screen.queryByAltText("Information Icon")).not.toBeInTheDocument();
+  });
+
+  it("clicking the icon opens the modal with page content", () => {
+    render(<InformationIcon pageKey={"splash"} />);
+    fireEvent.click(screen.getByAltText("Information Icon"));
+    expect(screen.getByTestId("modal-base")).toBeInTheDocument();
+    expect(
+      screen.getByText("This is test information content."),
+    ).toBeInTheDocument();
+  });
+});

--- a/components/ui/InteractionPanel/InteractionPanel.test.tsx
+++ b/components/ui/InteractionPanel/InteractionPanel.test.tsx
@@ -1,4 +1,60 @@
-describe('InteractionPanel', () => {
-  test.todo('renders the panel title');
-  test.todo('renders all option items passed via optionArray');
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import InteractionPanel, { PanelOption } from "./InteractionPanel";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({ push: mockPush })),
+}));
+
+const mockOptions: PanelOption[] = [
+  {
+    id: 1,
+    name: "Quest Board",
+    pageRoute: "/quest-board",
+    src: "/icons/quest_board.png",
+    altText: "Quest Board Icon",
+  },
+  {
+    id: 2,
+    name: "Market",
+    pageRoute: "/market",
+    src: "/icons/market.png",
+    altText: "Market Icon",
+  },
+];
+
+/*
+ * Story: Player views and interacts with the Interaction Panel
+ * In order to navigate the game world,
+ * a player wants to see available options and click them to navigate to the correct screen.
+ *
+ * Scenario: Panel title is displayed
+ *   Given the InteractionPanel is rendered with a title
+ *   When the component mounts
+ *   Then I should see the panel title
+ *
+ * Scenario: All option items are rendered
+ *   Given the InteractionPanel is rendered with an optionArray
+ *   When the component mounts
+ *   Then I should see a button for each option with the correct name
+ */
+describe("InteractionPanel", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the panel title", () => {
+    render(<InteractionPanel title="Town Square" optionArray={mockOptions} />);
+    expect(screen.getByText("Town Square")).toBeInTheDocument();
+  });
+
+  it("renders all option items passed via optionArray", () => {
+    render(<InteractionPanel title="Town Square" optionArray={mockOptions} />);
+    mockOptions.forEach((option) => {
+      expect(screen.getByText(option.name)).toBeInTheDocument();
+    });
+  });
 });

--- a/components/ui/LoadingSpinner/LoadingSpinner.test.tsx
+++ b/components/ui/LoadingSpinner/LoadingSpinner.test.tsx
@@ -1,3 +1,21 @@
-describe('LoadingSpinner', () => {
-  test.todo('renders a spinner with accessible status role');
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import LoadingSpinner from "./LoadingSpinner";
+
+/*
+ * Story: Player sees a loading indicator during async operations
+ * In order to understand the app is working,
+ * a player should see a visible loading spinner while waiting for a response.
+ *
+ * Scenario: Spinner renders with accessible status role
+ *   Given an async operation is in progress
+ *   When the LoadingSpinner is rendered
+ *   Then it should be present in the DOM with a status role for accessibility
+ */
+describe("LoadingSpinner", () => {
+  it("renders a spinner with accessible status role", () => {
+    render(<LoadingSpinner />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
 });

--- a/components/ui/LocationModal/LocationModal.test.tsx
+++ b/components/ui/LocationModal/LocationModal.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import LocationModal from "./LocationModal";
 
 const mockCloseModal = jest.fn();
@@ -21,17 +21,25 @@ const mockCloseModal = jest.fn();
  *   Then the modal title should not be present in the DOM
  */
 describe("LocationModal", () => {
+  beforeAll(() => {
+    Element.prototype.getAnimations = () => [];
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it("renders modal when isOpen is true", () => {
-    render(<LocationModal isOpen={true} closeModal={mockCloseModal} />);
+  it("renders modal when isOpen is true", async () => {
+    await act(async () => {
+      render(<LocationModal isOpen={true} closeModal={mockCloseModal} />);
+    });
     expect(screen.getByText("Location Modal")).toBeInTheDocument();
   });
 
-  it("does not render modal content when isOpen is false", () => {
-    render(<LocationModal isOpen={false} closeModal={mockCloseModal} />);
+  it("does not render modal content when isOpen is false", async () => {
+    await act(async () => {
+      render(<LocationModal isOpen={false} closeModal={mockCloseModal} />);
+    });
     expect(screen.queryByText("Location Modal")).not.toBeInTheDocument();
   });
 });

--- a/components/ui/LocationModal/LocationModal.test.tsx
+++ b/components/ui/LocationModal/LocationModal.test.tsx
@@ -1,4 +1,37 @@
-describe('LocationModal', () => {
-  test.todo('renders modal when isOpen is true');
-  test.todo('does not render modal content when isOpen is false');
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import LocationModal from "./LocationModal";
+
+const mockCloseModal = jest.fn();
+
+/*
+ * Story: Player views location details on the map
+ * In order to learn about and change their character's location,
+ * a player wants to open a modal that displays location information.
+ *
+ * Scenario: Modal content is visible when open
+ *   Given I am on a screen with a LocationModal
+ *   When the modal is open
+ *   Then I should see the modal title and description
+ *
+ * Scenario: Modal content is not visible when closed
+ *   Given I am on a screen with a LocationModal
+ *   When the modal is closed
+ *   Then the modal title should not be present in the DOM
+ */
+describe("LocationModal", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders modal when isOpen is true", () => {
+    render(<LocationModal isOpen={true} closeModal={mockCloseModal} />);
+    expect(screen.getByText("Location Modal")).toBeInTheDocument();
+  });
+
+  it("does not render modal content when isOpen is false", () => {
+    render(<LocationModal isOpen={false} closeModal={mockCloseModal} />);
+    expect(screen.queryByText("Location Modal")).not.toBeInTheDocument();
+  });
 });

--- a/components/ui/LoginModal/LoginModal.test.tsx
+++ b/components/ui/LoginModal/LoginModal.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import LoginModal from "./LoginModal";
 
 const mockCloseModal = jest.fn();
@@ -47,17 +47,25 @@ const defaultProps = {
  *   Then the modal should close
  */
 describe("LoginModal", () => {
+  beforeAll(() => {
+    Element.prototype.getAnimations = () => [];
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it("renders with title text", () => {
-    render(<LoginModal {...defaultProps} />);
+  it("renders with title text", async () => {
+    await act(async () => {
+      render(<LoginModal {...defaultProps} />);
+    });
     expect(screen.getByText("Continue your quest!")).toBeInTheDocument();
   });
 
-  it("shows validation error for invalid email format", () => {
-    render(<LoginModal {...defaultProps} />);
+  it("shows validation error for invalid email format", async () => {
+    await act(async () => {
+      render(<LoginModal {...defaultProps} />);
+    });
 
     const usernameInput = screen.getByPlaceholderText("email@address.com");
     fireEvent.change(usernameInput, { target: { value: "notanemail" } });
@@ -68,8 +76,10 @@ describe("LoginModal", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows validation error for short password", () => {
-    render(<LoginModal {...defaultProps} />);
+  it("shows validation error for short password", async () => {
+    await act(async () => {
+      render(<LoginModal {...defaultProps} />);
+    });
 
     const passwordInput = screen.getByPlaceholderText("Password");
     fireEvent.change(passwordInput, { target: { value: "123" } });
@@ -80,13 +90,17 @@ describe("LoginModal", () => {
     ).toBeInTheDocument();
   });
 
-  it("Login button is disabled when fields are invalid", () => {
-    render(<LoginModal {...defaultProps} />);
+  it("Login button is disabled when fields are invalid", async () => {
+    await act(async () => {
+      render(<LoginModal {...defaultProps} />);
+    });
     expect(screen.getByRole("button", { name: /login/i })).toBeDisabled();
   });
 
-  it("clicking Cancel closes the modal", () => {
-    render(<LoginModal {...defaultProps} />);
+  it("clicking Cancel closes the modal", async () => {
+    await act(async () => {
+      render(<LoginModal {...defaultProps} />);
+    });
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
     expect(mockCloseModal).toHaveBeenCalledTimes(1);
   });

--- a/components/ui/LoginModal/LoginModal.test.tsx
+++ b/components/ui/LoginModal/LoginModal.test.tsx
@@ -1,20 +1,93 @@
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import LoginModal from "./LoginModal";
 
-import LoginModal from './LoginModal';
+const mockCloseModal = jest.fn();
+const mockHandleLoginAndLoadCharacter = jest.fn();
 
-jest.mock('next/navigation', () => ({
-  useRouter: jest.fn(),
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({ push: jest.fn() })),
 }));
 
-describe('LoginModal', () => {
-  it('Component renders with title text', () => {
-    render(<LoginModal isOpen={true} closeModal={() => {}} />);
+const defaultProps = {
+  isOpen: true,
+  closeModal: mockCloseModal,
+  handleLoginAndLoadCharacter: mockHandleLoginAndLoadCharacter,
+};
 
-    const title = screen.getByText('Continue your quest!');
-
-    expect(title).toBeInTheDocument();
+/*
+ * Story: Player logs into their account via the Login Modal
+ * In order to continue their adventure,
+ * a player wants to enter their credentials and authenticate successfully.
+ *
+ * Scenario: Modal renders with title text
+ *   Given the LoginModal is open
+ *   When the component mounts
+ *   Then I should see the modal title
+ *
+ * Scenario: Username field shows error on invalid email format
+ *   Given the LoginModal is open
+ *   When I enter an invalid email and blur the field
+ *   Then I should see a username validation error
+ *
+ * Scenario: Password field shows error when too short
+ *   Given the LoginModal is open
+ *   When I enter a short password and blur the field
+ *   Then I should see a password validation error
+ *
+ * Scenario: Login button is disabled when fields are invalid
+ *   Given the LoginModal is open
+ *   When I have not entered valid credentials
+ *   Then the Login button should be disabled
+ *
+ * Scenario: Player clicks Cancel
+ *   Given the LoginModal is open
+ *   When I click the Cancel button
+ *   Then the modal should close
+ */
+describe("LoginModal", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  // Add test for input validation
+  it("renders with title text", () => {
+    render(<LoginModal {...defaultProps} />);
+    expect(screen.getByText("Continue your quest!")).toBeInTheDocument();
+  });
+
+  it("shows validation error for invalid email format", () => {
+    render(<LoginModal {...defaultProps} />);
+
+    const usernameInput = screen.getByPlaceholderText("email@address.com");
+    fireEvent.change(usernameInput, { target: { value: "notanemail" } });
+    fireEvent.blur(usernameInput);
+
+    expect(
+      screen.getByText("Username should be an email@domain.com format"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows validation error for short password", () => {
+    render(<LoginModal {...defaultProps} />);
+
+    const passwordInput = screen.getByPlaceholderText("Password");
+    fireEvent.change(passwordInput, { target: { value: "123" } });
+    fireEvent.blur(passwordInput);
+
+    expect(
+      screen.getByText("Password must be at least 7 characters long"),
+    ).toBeInTheDocument();
+  });
+
+  it("Login button is disabled when fields are invalid", () => {
+    render(<LoginModal {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /login/i })).toBeDisabled();
+  });
+
+  it("clicking Cancel closes the modal", () => {
+    render(<LoginModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(mockCloseModal).toHaveBeenCalledTimes(1);
+  });
 });

--- a/components/ui/LoginModal/LoginModal.tsx
+++ b/components/ui/LoginModal/LoginModal.tsx
@@ -196,9 +196,6 @@ export default function LoginModal({
           );
         }
 
-        // log refresh data saved successfully
-        console.log("Session refresh data saved successfully.");
-
         // call the handleLoginAndLoadCharacter function with the loaded character data and location, only if characterData exists
         handleLoginAndLoadCharacter(
           user,

--- a/components/ui/LogoutButton/LogoutButton.test.tsx
+++ b/components/ui/LogoutButton/LogoutButton.test.tsx
@@ -1,21 +1,53 @@
-import '@testing-library/jest-dom';
-import { screen } from '@testing-library/react';
-import { renderWithStore } from '@/lib/test-utils';
-import LogoutButton from './LogoutButton';
+import React from "react";
+import "@testing-library/jest-dom";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithStore } from "@/lib/test-utils";
+import LogoutButton from "./LogoutButton";
+import { clearSessionRefreshData } from "@/lib/persistence/localPersistence";
 
-jest.mock('next/navigation', () => ({
-  useRouter: jest.fn(() => ({ push: jest.fn() })),
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({ push: mockPush })),
 }));
 
-jest.mock('@/lib/persistence/localPersistence', () => ({
+jest.mock("@/lib/persistence/localPersistence", () => ({
   clearSessionRefreshData: jest.fn(),
 }));
 
-describe('LogoutButton', () => {
-  it('renders the logout icon button', () => {
-    renderWithStore(<LogoutButton />);
-    expect(screen.getByAltText('Logout Icon')).toBeInTheDocument();
+/*
+ * Story: Player logs out of their session
+ * In order to protect their account and end their session,
+ * a player wants to click a logout button that clears their data and returns them to the splash screen.
+ *
+ * Scenario: Logout button is visible
+ *   Given I am on a screen with a LogoutButton
+ *   When the component renders
+ *   Then I should see the logout icon
+ *
+ * Scenario: Player clicks the logout button
+ *   Given I am logged in
+ *   When I click the logout button
+ *   Then session data should be cleared and I should be redirected to the splash screen
+ */
+describe("LogoutButton", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  // add test for logout functionality
+  it("renders the logout icon button", () => {
+    renderWithStore(<LogoutButton />);
+    expect(screen.getByAltText("Logout Icon")).toBeInTheDocument();
+  });
+
+  it("clicking logout clears session data and redirects to splash screen", () => {
+    const mockedClearSession = jest.mocked(clearSessionRefreshData);
+    const { store } = renderWithStore(<LogoutButton />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(mockedClearSession).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith("/");
+    expect(store.getState().auth?.isAuthenticated).toBe(false);
+  });
 });

--- a/components/ui/LogoutButton/LogoutButton.tsx
+++ b/components/ui/LogoutButton/LogoutButton.tsx
@@ -29,9 +29,6 @@ export default function LogoutButton() {
 
     setIsLoading(false);
 
-    console.log(
-      "User logged out, session refresh data cleared, and state reset. Redirecting to splash screen...",
-    );
     router.push("/");
   };
 

--- a/components/ui/MarketBooth/MarketBooth.test.tsx
+++ b/components/ui/MarketBooth/MarketBooth.test.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithStore } from "@/lib/test-utils";
+import { MarketBooth } from "./MarketBooth";
+import { usePathname } from "next/navigation";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({ push: mockPush })),
+  usePathname: jest.fn(),
+}));
+
+/* 
+Modal mocked to avoid headless UI error about missing app element in tests, 
+allowing for testing of modal open state without needing to interact with 
+the actual modal content.
+*/
+jest.mock("./components/ItemPurchaseModal", () => ({
+  ItemPurchaseModal: ({
+    isOpen,
+    children,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+  }) => (isOpen ? <div data-testid="purchase-modal">{children}</div> : null),
+}));
+
+const baseState = {
+  auth: {
+    isAuthenticated: false,
+    user: null,
+  },
+  quest: {
+    availableQuests: [],
+    acceptedQuest: null,
+    currentStoryPointId: null,
+    lastEndedQuestId: null,
+    pendingBattleDetails: null,
+  },
+  character: {
+    ActiveCharacter: {
+      id: "char-001",
+      name: "Aric",
+      avatar: "/character_avatars/aric.png",
+      hp: 100,
+      mp: 50,
+      inventory: {
+        attacks: [],
+        skills: [],
+        coins: { gold: 100, silver: 50, copper: 25 },
+        weapons: [],
+        equipment: [],
+        rations: [],
+        potions: [],
+        questItems: [],
+      },
+    },
+    characterLocation: null,
+    party: [],
+    completedQuestIds: [],
+    characterData: null,
+    location: null,
+    characterSnapshot: null,
+  },
+};
+
+/*
+ * Story: Player browses and purchases items at the Market Booth
+ * In order to equip their character,
+ * a player wants to view items available in the current market section and purchase them.
+ *
+ * Scenario: Booth renders no items on an unrecognized route
+ *   Given I am on a route that is not a market section
+ *   When the MarketBooth renders
+ *   Then no booth items should be displayed
+ *
+ * Scenario: Booth renders items for the weapons market route
+ *   Given I am on the weapons market route
+ *   When the MarketBooth renders
+ *   Then weapon items should be displayed
+ *
+ * Scenario: Clicking a booth item opens the purchase modal
+ *   Given I am on the weapons market route with affordable items
+ *   When I click a booth item
+ *   Then the purchase modal should open
+ */
+describe("MarketBooth", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders no booth items on an unrecognized route", () => {
+    (usePathname as jest.Mock).mockReturnValue("/marketscreen");
+    renderWithStore(<MarketBooth />, baseState);
+    expect(
+      screen.queryByRole("button", { name: /gold|silver|copper/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders booth items for the weapons market route", () => {
+    (usePathname as jest.Mock).mockReturnValue("/marketscreen/weapons");
+    renderWithStore(<MarketBooth />, baseState);
+    const items = screen.getAllByRole("button");
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  it("clicking a booth item opens the purchase modal", () => {
+    (usePathname as jest.Mock).mockReturnValue("/marketscreen/weapons");
+    renderWithStore(<MarketBooth />, baseState);
+    const enabledItems = screen
+      .getAllByRole("button")
+      .filter((btn) => !btn.hasAttribute("disabled"));
+    expect(enabledItems.length).toBeGreaterThan(0);
+    fireEvent.click(enabledItems[0]);
+    expect(screen.getByTestId("purchase-modal")).toBeInTheDocument();
+  });
+});

--- a/components/ui/MarketBooth/MarketBooth.tsx
+++ b/components/ui/MarketBooth/MarketBooth.tsx
@@ -14,15 +14,10 @@ import { allEquipment } from '@/data/gameData/equipment';
 import { allPotions } from '@/data/gameData/potions';
 import { allRations } from '@/data/gameData/rations';
 import { allWeapons } from '@/data/gameData/weapons';
-import { Coins, InventoryItemBase } from '@/types/character';
+import { InventoryItemBase } from '@/types/character';
 import { ItemPurchaseModal } from './components/ItemPurchaseModal';
+import { canAffordItem, formatPriceDisplay } from './utils/marketBooth.utils';
 import { useRef, useState } from 'react';
-
-export type priceObject = {
-  label: string;
-  shortLabel: string;
-  amount: number;
-};
 
 export const MarketBooth = () => {
   const pathname = usePathname();
@@ -50,62 +45,6 @@ export const MarketBooth = () => {
       default:
         return [];
     }
-  };
-
-  // move to lib folder later
-  const formatPriceDisplay = (price: Coins): priceObject => {
-    // return price data as formatted price object
-    let formattedPrice: priceObject = {
-      label: '',
-      shortLabel: '',
-      amount: 0,
-    };
-
-    if (price.gold && price.gold > 0) {
-      formattedPrice = {
-        label: `${price.gold} Gold`,
-        shortLabel: `${price.gold}G`,
-        amount: price.gold,
-      };
-    } else if (price.silver && price.silver > 0) {
-      formattedPrice = {
-        label: `${price.silver} Silver`,
-        shortLabel: `${price.silver}S`,
-        amount: price.silver,
-      };
-    } else if (price.copper && price.copper > 0) {
-      formattedPrice = {
-        label: `${price.copper} Copper`,
-        shortLabel: `${price.copper}C`,
-        amount: price.copper,
-      };
-    }
-    return formattedPrice;
-  };
-
-  // move to lib folder later
-  const canAffordItem = (price: Coins): boolean => {
-    // check if activeCharacter can afford item based on price object
-    if (
-      !activeCharacter ||
-      !activeCharacter.inventory ||
-      !activeCharacter.inventory.coins
-    ) {
-      return false;
-    }
-
-    const characterCoins = activeCharacter.inventory.coins;
-
-    if (price.gold && characterCoins.gold < price.gold) {
-      return false;
-    }
-    if (price.silver && characterCoins.silver < price.silver) {
-      return false;
-    }
-    if (price.copper && characterCoins.copper < price.copper) {
-      return false;
-    }
-    return true;
   };
 
   const boothItems: InventoryItemBase[] = setDisplayItems();
@@ -202,7 +141,7 @@ export const MarketBooth = () => {
                                     transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300
                                     disabled:grayscale disabled:brightness-75 disabled:cursor-not-allowed
                                     '
-                disabled={!item.price || !canAffordItem(item.price)} // disable if no price or cannot afford
+                disabled={!item.price || !canAffordItem(activeCharacter?.inventory?.coins, item.price)} // disable if no price or cannot afford
                 onClick={() => handleBoothItemClick(item)}
               >
                 <Image

--- a/components/ui/MarketBooth/components/ItemPurchaseModal.test.tsx
+++ b/components/ui/MarketBooth/components/ItemPurchaseModal.test.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ItemPurchaseModal } from "./ItemPurchaseModal";
+import { InventoryItemBase } from "@/types/character";
+
+const mockCloseModal = jest.fn();
+const mockHandleItemPurchase = jest.fn();
+
+jest.mock("../../ModalBase/ModalBase", () => ({
+  ModalBase: ({
+    isOpen,
+    title,
+    children,
+  }: {
+    isOpen: boolean;
+    title: string;
+    children: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div data-testid="modal-base">
+        <h2>{title}</h2>
+        {children}
+      </div>
+    ) : null,
+}));
+
+const mockWeapon: InventoryItemBase = {
+  id: "weapon-001",
+  title: "Iron Sword",
+  description: "A basic iron sword.",
+  icon: "/icons/iron_sword.png",
+  type: "weapon",
+  price: { gold: 10, silver: 0, copper: 0 },
+  effect: {},
+};
+
+const mockPotion: InventoryItemBase = {
+  id: "potion-001",
+  title: "Health Potion",
+  description: "Restores 50 HP.",
+  icon: "/icons/health_potion.png",
+  type: "potion",
+  price: { gold: 0, silver: 5, copper: 0 },
+  effect: {},
+};
+
+/*
+ * Story: Player reviews and purchases an item from a market booth
+ * In order to equip or supply their character,
+ * a player wants to see item details and confirm a purchase via the ItemPurchaseModal.
+ *
+ * Scenario: Modal renders null when no item is provided
+ *   Given no booth item is passed
+ *   When the ItemPurchaseModal renders
+ *   Then nothing should be rendered
+ *
+ * Scenario: Modal renders item details when open
+ *   Given a booth item is passed and the modal is open
+ *   When the ItemPurchaseModal renders
+ *   Then the item title and description should be visible
+ *
+ * Scenario: Modal title reflects the item type
+ *   Given a weapon item is passed
+ *   When the ItemPurchaseModal renders
+ *   Then the modal title should be "Weapons"
+ *
+ * Scenario: Modal title reflects potion item type
+ *   Given a potion item is passed
+ *   When the ItemPurchaseModal renders
+ *   Then the modal title should be "Potions"
+ *
+ * Scenario: Clicking Purchase calls handleItemPurchase with the item
+ *   Given the modal is open with a booth item
+ *   When I click the Purchase button
+ *   Then handleItemPurchase should be called with the item
+ *
+ * Scenario: Clicking Close calls closeModal
+ *   Given the modal is open with a booth item
+ *   When I click the Close button
+ *   Then closeModal should be called
+ */
+describe("ItemPurchaseModal", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders null when no booth item is provided", () => {
+    render(
+      <ItemPurchaseModal
+        isOpen={true}
+        closeModal={mockCloseModal}
+        boothItem={null}
+        handleItemPurchase={mockHandleItemPurchase}
+      />,
+    );
+    expect(screen.queryByTestId("modal-base")).not.toBeInTheDocument();
+  });
+
+  it("renders item title and description when open", () => {
+    render(
+      <ItemPurchaseModal
+        isOpen={true}
+        closeModal={mockCloseModal}
+        boothItem={mockWeapon}
+        handleItemPurchase={mockHandleItemPurchase}
+      />,
+    );
+    expect(screen.getByText("Iron Sword")).toBeInTheDocument();
+    expect(screen.getByText("A basic iron sword.")).toBeInTheDocument();
+  });
+
+  it("renders the correct title for a weapon item type", () => {
+    render(
+      <ItemPurchaseModal
+        isOpen={true}
+        closeModal={mockCloseModal}
+        boothItem={mockWeapon}
+        handleItemPurchase={mockHandleItemPurchase}
+      />,
+    );
+    expect(screen.getByText("Weapons")).toBeInTheDocument();
+  });
+
+  it("renders the correct title for a potion item type", () => {
+    render(
+      <ItemPurchaseModal
+        isOpen={true}
+        closeModal={mockCloseModal}
+        boothItem={mockPotion}
+        handleItemPurchase={mockHandleItemPurchase}
+      />,
+    );
+    expect(screen.getByText("Potions")).toBeInTheDocument();
+  });
+
+  it("clicking Purchase calls handleItemPurchase with the item", () => {
+    render(
+      <ItemPurchaseModal
+        isOpen={true}
+        closeModal={mockCloseModal}
+        boothItem={mockWeapon}
+        handleItemPurchase={mockHandleItemPurchase}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /purchase/i }));
+    expect(mockHandleItemPurchase).toHaveBeenCalledTimes(1);
+    expect(mockHandleItemPurchase).toHaveBeenCalledWith(mockWeapon);
+  });
+
+  it("clicking Close calls closeModal", () => {
+    render(
+      <ItemPurchaseModal
+        isOpen={true}
+        closeModal={mockCloseModal}
+        boothItem={mockWeapon}
+        handleItemPurchase={mockHandleItemPurchase}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(mockCloseModal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/ui/MarketBooth/utils/marketBooth.utils.test.ts
+++ b/components/ui/MarketBooth/utils/marketBooth.utils.test.ts
@@ -1,0 +1,96 @@
+import { formatPriceDisplay, canAffordItem } from "./marketBooth.utils";
+import { Coins } from "@/types/character";
+
+/*
+ * Story: Market booth displays accurate pricing and purchase eligibility
+ * In order to make informed purchases,
+ * a player wants to see correctly formatted prices and know which items they can afford.
+ *
+ * Scenario: formatPriceDisplay returns gold label when gold value is set
+ *   Given a price with a gold value
+ *   When formatPriceDisplay is called
+ *   Then it should return a formatted gold label and amount
+ *
+ * Scenario: formatPriceDisplay returns silver label when only silver is set
+ *   Given a price with a silver value and no gold
+ *   When formatPriceDisplay is called
+ *   Then it should return a formatted silver label and amount
+ *
+ * Scenario: formatPriceDisplay returns copper label when only copper is set
+ *   Given a price with a copper value and no gold or silver
+ *   When formatPriceDisplay is called
+ *   Then it should return a formatted copper label and amount
+ *
+ * Scenario: formatPriceDisplay returns empty label when all values are zero
+ *   Given a price with all zero values
+ *   When formatPriceDisplay is called
+ *   Then it should return an empty label and zero amount
+ *
+ * Scenario: canAffordItem returns true when character has enough coins
+ *   Given a character with sufficient coins
+ *   When canAffordItem is called
+ *   Then it should return true
+ *
+ * Scenario: canAffordItem returns false when character cannot afford the item
+ *   Given a character with insufficient coins
+ *   When canAffordItem is called
+ *   Then it should return false
+ *
+ * Scenario: canAffordItem returns false when character coins are undefined
+ *   Given no character coins are provided
+ *   When canAffordItem is called
+ *   Then it should return false
+ */
+describe("marketBooth.utils", () => {
+  describe("formatPriceDisplay", () => {
+    it("returns gold label and amount when gold value is set", () => {
+      const price: Coins = { gold: 10, silver: 0, copper: 0 };
+      const result = formatPriceDisplay(price);
+      expect(result.label).toBe("10 Gold");
+      expect(result.shortLabel).toBe("10G");
+      expect(result.amount).toBe(10);
+    });
+
+    it("returns silver label and amount when only silver is set", () => {
+      const price: Coins = { gold: 0, silver: 5, copper: 0 };
+      const result = formatPriceDisplay(price);
+      expect(result.label).toBe("5 Silver");
+      expect(result.shortLabel).toBe("5S");
+      expect(result.amount).toBe(5);
+    });
+
+    it("returns copper label and amount when only copper is set", () => {
+      const price: Coins = { gold: 0, silver: 0, copper: 25 };
+      const result = formatPriceDisplay(price);
+      expect(result.label).toBe("25 Copper");
+      expect(result.shortLabel).toBe("25C");
+      expect(result.amount).toBe(25);
+    });
+
+    it("returns empty label and zero amount when all values are zero", () => {
+      const price: Coins = { gold: 0, silver: 0, copper: 0 };
+      const result = formatPriceDisplay(price);
+      expect(result.label).toBe("");
+      expect(result.amount).toBe(0);
+    });
+  });
+
+  describe("canAffordItem", () => {
+    it("returns true when character has enough gold", () => {
+      const characterCoins: Coins = { gold: 20, silver: 0, copper: 0 };
+      const price: Coins = { gold: 10, silver: 0, copper: 0 };
+      expect(canAffordItem(characterCoins, price)).toBe(true);
+    });
+
+    it("returns false when character does not have enough gold", () => {
+      const characterCoins: Coins = { gold: 5, silver: 0, copper: 0 };
+      const price: Coins = { gold: 10, silver: 0, copper: 0 };
+      expect(canAffordItem(characterCoins, price)).toBe(false);
+    });
+
+    it("returns false when character coins are undefined", () => {
+      const price: Coins = { gold: 10, silver: 0, copper: 0 };
+      expect(canAffordItem(undefined, price)).toBe(false);
+    });
+  });
+});

--- a/components/ui/MarketBooth/utils/marketBooth.utils.ts
+++ b/components/ui/MarketBooth/utils/marketBooth.utils.ts
@@ -1,0 +1,56 @@
+import { Coins } from '@/types/character';
+
+export type priceObject = {
+  label: string;
+  shortLabel: string;
+  amount: number;
+};
+
+export const formatPriceDisplay = (price: Coins): priceObject => {
+  let formattedPrice: priceObject = {
+    label: '',
+    shortLabel: '',
+    amount: 0,
+  };
+
+  if (price.gold && price.gold > 0) {
+    formattedPrice = {
+      label: `${price.gold} Gold`,
+      shortLabel: `${price.gold}G`,
+      amount: price.gold,
+    };
+  } else if (price.silver && price.silver > 0) {
+    formattedPrice = {
+      label: `${price.silver} Silver`,
+      shortLabel: `${price.silver}S`,
+      amount: price.silver,
+    };
+  } else if (price.copper && price.copper > 0) {
+    formattedPrice = {
+      label: `${price.copper} Copper`,
+      shortLabel: `${price.copper}C`,
+      amount: price.copper,
+    };
+  }
+  return formattedPrice;
+};
+
+export const canAffordItem = (
+  characterCoins: Coins | undefined,
+  price: Coins
+): boolean => {
+  if (!characterCoins) {
+    return false;
+  }
+
+  if (price.gold && characterCoins.gold < price.gold) {
+    return false;
+  }
+  if (price.silver && characterCoins.silver < price.silver) {
+    return false;
+  }
+  if (price.copper && characterCoins.copper < price.copper) {
+    return false;
+  }
+  return true;
+};

--- a/components/ui/ModalBase/ModalBase.test.tsx
+++ b/components/ui/ModalBase/ModalBase.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { ModalBase } from "./ModalBase";
 
 const mockCloseModal = jest.fn();
@@ -36,79 +36,93 @@ const mockCloseModal = jest.fn();
  *   Then closeModal should be called
  */
 describe("ModalBase", () => {
+  beforeAll(() => {
+    Element.prototype.getAnimations = () => [];
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it("renders children when open", () => {
-    render(
-      <ModalBase
-        isOpen={true}
-        type="read-only"
-        closeModal={mockCloseModal}
-        title=""
-      >
-        <div>Modal Child Content</div>
-      </ModalBase>,
-    );
+  it("renders children when open", async () => {
+    await act(async () => {
+      render(
+        <ModalBase
+          isOpen={true}
+          type="read-only"
+          closeModal={mockCloseModal}
+          title=""
+        >
+          <div>Modal Child Content</div>
+        </ModalBase>,
+      );
+    });
     expect(screen.getByText("Modal Child Content")).toBeInTheDocument();
   });
 
-  it("renders the title when provided", () => {
-    render(
-      <ModalBase
-        isOpen={true}
-        type="read-only"
-        closeModal={mockCloseModal}
-        title="Test Title"
-      >
-        <div>Content</div>
-      </ModalBase>,
-    );
+  it("renders the title when provided", async () => {
+    await act(async () => {
+      render(
+        <ModalBase
+          isOpen={true}
+          type="read-only"
+          closeModal={mockCloseModal}
+          title="Test Title"
+        >
+          <div>Content</div>
+        </ModalBase>,
+      );
+    });
     expect(screen.getByText("Test Title")).toBeInTheDocument();
   });
 
-  it("renders a Close button for read-only type", () => {
-    render(
-      <ModalBase
-        isOpen={true}
-        type="read-only"
-        closeModal={mockCloseModal}
-        title=""
-      >
-        <div>Content</div>
-      </ModalBase>,
-    );
+  it("renders a Close button for read-only type", async () => {
+    await act(async () => {
+      render(
+        <ModalBase
+          isOpen={true}
+          type="read-only"
+          closeModal={mockCloseModal}
+          title=""
+        >
+          <div>Content</div>
+        </ModalBase>,
+      );
+    });
     expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument();
   });
 
-  it("does not render a Close button for action type", () => {
-    render(
-      <ModalBase
-        isOpen={true}
-        type="action"
-        closeModal={mockCloseModal}
-        title=""
-      >
-        <div>Content</div>
-      </ModalBase>,
-    );
+  it("does not render a Close button for action type", async () => {
+    await act(async () => {
+      render(
+        <ModalBase
+          isOpen={true}
+          type="action"
+          closeModal={mockCloseModal}
+          title=""
+        >
+          <div>Content</div>
+        </ModalBase>,
+      );
+    });
     expect(
       screen.queryByRole("button", { name: /close/i }),
     ).not.toBeInTheDocument();
   });
 
-  it("clicking Close calls closeModal", () => {
-    render(
-      <ModalBase
-        isOpen={true}
-        type="read-only"
-        closeModal={mockCloseModal}
-        title=""
-      >
-        <div>Content</div>
-      </ModalBase>,
-    );
+  it("clicking Close calls closeModal", async () => {
+    await act(async () => {
+      render(
+        <ModalBase
+          isOpen={true}
+          type="read-only"
+          closeModal={mockCloseModal}
+          title=""
+        >
+          <div>Content</div>
+        </ModalBase>,
+      );
+    });
     fireEvent.click(screen.getByRole("button", { name: /close/i }));
     expect(mockCloseModal).toHaveBeenCalledTimes(1);
   });

--- a/components/ui/ModalBase/ModalBase.test.tsx
+++ b/components/ui/ModalBase/ModalBase.test.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ModalBase } from "./ModalBase";
+
+const mockCloseModal = jest.fn();
+
+/*
+ * Story: Player interacts with a base modal
+ * In order to view content or take action,
+ * a player wants to open a modal that displays content and can be closed.
+ *
+ * Scenario: Modal renders children when open
+ *   Given the ModalBase is open
+ *   When the component renders
+ *   Then the child content should be visible
+ *
+ * Scenario: Modal renders a title when provided
+ *   Given the ModalBase is open with a title
+ *   When the component renders
+ *   Then the title should be visible
+ *
+ * Scenario: Read-only modal renders a Close button
+ *   Given the ModalBase is open with type read-only
+ *   When the component renders
+ *   Then a Close button should be visible
+ *
+ * Scenario: Action modal does not render a Close button
+ *   Given the ModalBase is open with type action
+ *   When the component renders
+ *   Then no Close button should be present
+ *
+ * Scenario: Clicking Close calls closeModal
+ *   Given the ModalBase is open with type read-only
+ *   When I click the Close button
+ *   Then closeModal should be called
+ */
+describe("ModalBase", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders children when open", () => {
+    render(
+      <ModalBase
+        isOpen={true}
+        type="read-only"
+        closeModal={mockCloseModal}
+        title=""
+      >
+        <div>Modal Child Content</div>
+      </ModalBase>,
+    );
+    expect(screen.getByText("Modal Child Content")).toBeInTheDocument();
+  });
+
+  it("renders the title when provided", () => {
+    render(
+      <ModalBase
+        isOpen={true}
+        type="read-only"
+        closeModal={mockCloseModal}
+        title="Test Title"
+      >
+        <div>Content</div>
+      </ModalBase>,
+    );
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+  });
+
+  it("renders a Close button for read-only type", () => {
+    render(
+      <ModalBase
+        isOpen={true}
+        type="read-only"
+        closeModal={mockCloseModal}
+        title=""
+      >
+        <div>Content</div>
+      </ModalBase>,
+    );
+    expect(screen.getByRole("button", { name: /close/i })).toBeInTheDocument();
+  });
+
+  it("does not render a Close button for action type", () => {
+    render(
+      <ModalBase
+        isOpen={true}
+        type="action"
+        closeModal={mockCloseModal}
+        title=""
+      >
+        <div>Content</div>
+      </ModalBase>,
+    );
+    expect(
+      screen.queryByRole("button", { name: /close/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clicking Close calls closeModal", () => {
+    render(
+      <ModalBase
+        isOpen={true}
+        type="read-only"
+        closeModal={mockCloseModal}
+        title=""
+      >
+        <div>Content</div>
+      </ModalBase>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(mockCloseModal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/ui/RefreshDataProvider/RefreshDataProvider.test.tsx
+++ b/components/ui/RefreshDataProvider/RefreshDataProvider.test.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { screen } from "@testing-library/react";
+import { renderWithStore } from "@/lib/test-utils";
+import { RefreshDataProvider } from "./RefreshDataProvider";
+import { loadSessionRefreshData } from "@/lib/persistence/localPersistence";
+import { PersistenceResponse } from "@/types/persistence";
+
+jest.mock("@/lib/persistence/localPersistence", () => ({
+  loadSessionRefreshData: jest.fn(),
+}));
+
+const mockLoadSessionRefreshData = jest.mocked(loadSessionRefreshData);
+
+const baseState = {
+  auth: {
+    isAuthenticated: false,
+    user: null,
+  },
+  quest: {
+    availableQuests: [
+      {
+        id: "ambushReconQuest",
+        name: "Ambush Alley Recon",
+        description: "Scout the bandit camp.",
+        coverImageSrc: "/quests/ambush_cover.png",
+        storyPoints: [],
+      },
+    ],
+    acceptedQuest: null,
+    currentStoryPointId: null,
+    lastEndedQuestId: null,
+    pendingBattleDetails: null,
+  },
+  character: {
+    ActiveCharacter: null,
+    characterLocation: null,
+    party: [],
+    completedQuestIds: [],
+    characterData: null,
+    location: null,
+    characterSnapshot: null,
+  },
+};
+
+const mockCharacter = {
+  id: "char-001",
+  name: "Aric",
+  avatar: "/character_avatars/aric.png",
+  hp: 100,
+  mp: 50,
+  inventory: {
+    attacks: [],
+    skills: [],
+    coins: { gold: 0, silver: 0, copper: 0 },
+    weapons: [],
+    equipment: [],
+    rations: [],
+    potions: [],
+    questItems: [],
+  },
+};
+
+const mockRefreshData: PersistenceResponse = {
+  success: true,
+  message: "Session refresh data loaded successfully.",
+  data: {
+    refreshSessionData: {
+      accountId: "account-001",
+      email: "aric@test.com",
+      playerId: "player-001",
+      acceptedQuestId: null,
+      currentStoryPointId: null,
+      lastEndedQuestId: null,
+      characterSnapshot: {
+        characterData: mockCharacter,
+        progressionData: {
+          completedQuestIds: [],
+          acceptedQuestId: null,
+          currentTown: "StartsVille",
+          currentStoryPointId: null,
+          lastEndedQuestId: null,
+        },
+      },
+    },
+  },
+};
+
+/*
+ * Story: Player's session is restored after a browser refresh
+ * In order to continue their adventure without logging in again,
+ * a player's auth, character, and quest state should be rehydrated from local storage on mount.
+ *
+ * Scenario: Children render after session data loads
+ *   Given valid session refresh data exists in local storage
+ *   When the RefreshDataProvider mounts
+ *   Then children should be visible after rehydration
+ *
+ * Scenario: Auth state is restored from session refresh data
+ *   Given valid session refresh data exists
+ *   When the RefreshDataProvider mounts
+ *   Then the store should reflect an authenticated user
+ *
+ * Scenario: Children render when no session data exists
+ *   Given no session refresh data exists in local storage
+ *   When the RefreshDataProvider mounts
+ *   Then children should still be rendered
+ */
+describe("RefreshDataProvider", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders children after session data is loaded", async () => {
+    mockLoadSessionRefreshData.mockReturnValue(mockRefreshData);
+
+    renderWithStore(
+      <RefreshDataProvider>
+        <div>Child Content</div>
+      </RefreshDataProvider>,
+      baseState,
+    );
+
+    expect(await screen.findByText("Child Content")).toBeInTheDocument();
+  });
+
+  it("restores auth state from session refresh data", async () => {
+    mockLoadSessionRefreshData.mockReturnValue(mockRefreshData);
+
+    const { store } = renderWithStore(
+      <RefreshDataProvider>
+        <div>Child Content</div>
+      </RefreshDataProvider>,
+      baseState,
+    );
+
+    await screen.findByText("Child Content");
+
+    expect(store.getState().auth.isAuthenticated).toBe(true);
+  });
+
+  it("renders children when no session refresh data exists", async () => {
+    mockLoadSessionRefreshData.mockReturnValue({
+      success: false,
+      data: null,
+      message: "No session refresh data found.",
+    } as PersistenceResponse);
+
+    renderWithStore(
+      <RefreshDataProvider>
+        <div>Child Content</div>
+      </RefreshDataProvider>,
+      baseState,
+    );
+
+    expect(await screen.findByText("Child Content")).toBeInTheDocument();
+  });
+});

--- a/components/ui/RefreshDataProvider/RefreshDataProvider.tsx
+++ b/components/ui/RefreshDataProvider/RefreshDataProvider.tsx
@@ -32,8 +32,6 @@ export const RefreshDataProvider = ({ children }: RefreshDataProviderProps) => {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    console.log("Checking for session refresh data in local storage...");
-
     if (availableQuests.length === 0) return; // wait for game data to load
 
     setIsLoading(true);
@@ -43,7 +41,6 @@ export const RefreshDataProvider = ({ children }: RefreshDataProviderProps) => {
 
     // Step 2: Stop if no valid refresh data exists
     if (!refreshResponse.success || !refreshResponse.data?.refreshSessionData) {
-      console.log("No session refresh data found in local storage.");
       setIsLoading(false);
 
       return;
@@ -68,8 +65,6 @@ export const RefreshDataProvider = ({ children }: RefreshDataProviderProps) => {
       setIsLoading(false);
       return;
     }
-
-    console.log("Session refresh data found:", refreshSessionData);
 
     // Step 5: Rebuild minimal auth user for Redux rehydration
     const user: User = {

--- a/components/ui/RegistrationModal/RegistrationModal.test.tsx
+++ b/components/ui/RegistrationModal/RegistrationModal.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import RegistrationModal from "./RegistrationModal";
 import { NewPlayerData } from "../../screens/CreateCharacterScreen/CreateCharacterScreen";
 
@@ -56,23 +56,33 @@ const defaultProps = {
  *   Then the modal should close
  */
 describe("RegistrationModal", () => {
+  beforeAll(() => {
+    Element.prototype.getAnimations = () => [];
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it("renders with title text", () => {
-    render(<RegistrationModal {...defaultProps} />);
+  it("renders with title text", async () => {
+    await act(async () => {
+      render(<RegistrationModal {...defaultProps} />);
+    });
     expect(screen.getByText("Your Player Data!")).toBeInTheDocument();
   });
 
-  it("renders player data when provided", () => {
-    render(<RegistrationModal {...defaultProps} playerData={mockPlayerData} />);
+  it("renders player data when provided", async () => {
+    await act(async () => {
+      render(<RegistrationModal {...defaultProps} playerData={mockPlayerData} />);
+    });
     expect(screen.getByText("Aric")).toBeInTheDocument();
     expect(screen.getByText("aric@test.com")).toBeInTheDocument();
   });
 
-  it("clicking Back closes the modal", () => {
-    render(<RegistrationModal {...defaultProps} />);
+  it("clicking Back closes the modal", async () => {
+    await act(async () => {
+      render(<RegistrationModal {...defaultProps} />);
+    });
     fireEvent.click(screen.getByRole("button", { name: /back/i }));
     expect(mockCloseModal).toHaveBeenCalledTimes(1);
   });

--- a/components/ui/RegistrationModal/RegistrationModal.test.tsx
+++ b/components/ui/RegistrationModal/RegistrationModal.test.tsx
@@ -1,22 +1,79 @@
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import RegistrationModal from "./RegistrationModal";
+import { NewPlayerData } from "../../screens/CreateCharacterScreen/CreateCharacterScreen";
 
-import RegistrationModal from './RegistrationModal';
+const mockCloseModal = jest.fn();
+const mockHandleCharacterCreationAndLogin = jest.fn();
 
-jest.mock('next/navigation', () => ({
-  useRouter: jest.fn(),
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({ push: jest.fn() })),
 }));
 
-// TODO: mock player data object and pass to RegistrationModal in later tests
+jest.mock("@/lib/persistence/localPersistence", () => ({
+  saveSessionRefreshData: jest.fn(),
+}));
 
-describe('RegistrationModal', () => {
-  it('Component renders with title text', () => {
-    render(<RegistrationModal isOpen={true} closeModal={() => {}} />);
+jest.mock("@/lib/persistence/persistence", () => ({
+  persistence: {
+    createAccount: jest.fn(),
+  },
+}));
 
-    const title = screen.getByText('Your Player Data!');
+const mockPlayerData: NewPlayerData = {
+  characterName: "Aric",
+  userName: "aric@test.com",
+  password: "password123",
+  avatar: "/character_avatars/default_avatar.png",
+  characterClass: "warrior",
+};
 
-    expect(title).toBeInTheDocument();
+const defaultProps = {
+  isOpen: true,
+  closeModal: mockCloseModal,
+  handleCharacterCreationAndLogin: mockHandleCharacterCreationAndLogin,
+};
+
+/*
+ * Story: Player reviews and confirms their character data before registration
+ * In order to create their account and begin their adventure,
+ * a player wants to review their chosen character details and submit registration.
+ *
+ * Scenario: Modal renders with title text
+ *   Given the RegistrationModal is open
+ *   When the component mounts
+ *   Then I should see the modal title
+ *
+ * Scenario: Modal displays player data when provided
+ *   Given the RegistrationModal is open with player data
+ *   When the component mounts
+ *   Then I should see the character name and username
+ *
+ * Scenario: Player clicks Back
+ *   Given the RegistrationModal is open
+ *   When I click the Back button
+ *   Then the modal should close
+ */
+describe("RegistrationModal", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  // Add test for registration button functionality
+  it("renders with title text", () => {
+    render(<RegistrationModal {...defaultProps} />);
+    expect(screen.getByText("Your Player Data!")).toBeInTheDocument();
+  });
+
+  it("renders player data when provided", () => {
+    render(<RegistrationModal {...defaultProps} playerData={mockPlayerData} />);
+    expect(screen.getByText("Aric")).toBeInTheDocument();
+    expect(screen.getByText("aric@test.com")).toBeInTheDocument();
+  });
+
+  it("clicking Back closes the modal", () => {
+    render(<RegistrationModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(mockCloseModal).toHaveBeenCalledTimes(1);
+  });
 });

--- a/components/ui/RegistrationModal/RegistrationModal.tsx
+++ b/components/ui/RegistrationModal/RegistrationModal.tsx
@@ -130,9 +130,6 @@ export default function RegistrationModal({
           // We can choose to continue even if saving session data fails, or handle it as needed
         }
 
-        // log that refresh data was saved successfully
-        console.log("Session refresh data saved successfully.");
-
         // call the character creation and login handler
         handleCharacterCreationAndLogin(
           user,

--- a/lib/features/character/CharacterSlice.ts
+++ b/lib/features/character/CharacterSlice.ts
@@ -36,7 +36,6 @@ type UpdateActiveCharacterPayload = {
 };
 
 export const convertItemTypeString = (item: InventorySelection): string => {
-  console.log("Converting item type for:", item.type);
   switch (item.type) {
     case "weapon":
       return "weapons";
@@ -90,9 +89,6 @@ export const purchaseBoothItemThunk = createAsyncThunk<
   // Ensure there is an active character
   if (!ActiveCharacter) return;
 
-  // purchase item logic
-  console.log(`Purchasing ${item.title} for ${ActiveCharacter?.name}`);
-
   // add item to character inventory
   if (!item.price) {
     console.warn("Item has no price, cannot complete purchase.");
@@ -114,9 +110,6 @@ export function applyEffectToCharacterThunk(effect: Effect) {
 
     // Ensure there is an active character
     if (!ActiveCharacter) return;
-
-    // apply effect logic
-    console.log(`Applying effect to ${ActiveCharacter?.name}:`, effect);
 
     // update hp/mp if present in effect
     if (effect.hp !== undefined || effect.mp !== undefined) {
@@ -179,8 +172,6 @@ export const characterSlice = createSlice({
       ) {
         return;
       }
-
-      console.log("Subtracting item price from character coins:", price);
 
       // remove purchases item price from character coins
       state.ActiveCharacter.inventory.coins = {


### PR DESCRIPTION
## Summary

### Overview
Completed all testing suite TODOs across `components/ui`, added RSpec-style test suites for all previously uncovered UI components, resolved Headless UI warnings, extracted utility functions, and removed debug console logs.

### Testing Suites Added
**TODO Suites Completed:**
- `BackButton` — render and navigation tests
- `CommenceModal` — render, commence, and cancel tests
- `DetailsModal` — render, accept, and cancel tests
- `InteractionPanel` — title and options rendering tests
- `LoadingSpinner` — accessible status role test
- `LocationModal` — open/closed state tests
- `LoginModal` — render, validation, disabled state, and cancel tests
- `LogoutButton` — render and logout functionality tests
- `RegistrationModal` — render, player data display, and cancel tests

**New Coverage Added:**
- `CharacterDisplayCard` — name, stats, and avatar tests
- `CoinsPanel` — coin rendering and formatCoinsForDisplay utility tests
- `ControlPanel` — pathname-based conditional rendering tests
- `GameDataProvider` — children rendering and quest dispatch tests
- `InformationIcon` — render, null state, and modal open tests
- `MarketBooth` — route-based item display and purchase modal tests
- `ModalBase` — children, title, type variants, and close tests
- `RefreshDataProvider` — session rehydration and auth state tests
- `ItemPurchaseModal` — null state, item details, title switching, and button tests
- `marketBooth.utils` — formatPriceDisplay and canAffordItem unit tests

### Refactoring
- Extracted `formatPriceDisplay` and `canAffordItem` from `MarketBooth.tsx` into `components/ui/MarketBooth/utils/marketBooth.utils.ts`
- Updated `MarketBooth.tsx` imports to reference new utils location
- Updated `canAffordItem` signature to accept coins as a parameter instead of closing over component state

### Bug Fixes & Cleanup
- Resolved Headless UI `act()` warnings across all Dialog-based test suites by wrapping render calls in `await act(async () => {})` and adding `Element.prototype.getAnimations` polyfill via `beforeAll`
- Removed all debug `console.log` statements from `RefreshDataProvider`, `LogoutButton`, `LoginModal`, `RegistrationModal`, and `CharacterSlice`

### Test Results
- **32 suites, 117 tests, 0 warnings**